### PR TITLE
Add Load Time, Total Machine Time and Total Run Time text boxes

### DIFF
--- a/tools/FileTree/uFileVirtualTree.pas
+++ b/tools/FileTree/uFileVirtualTree.pas
@@ -112,7 +112,7 @@ end;
 
 { TTreeData }
 
-procedure TTreeData.SetValue( _Value: String);
+function Fix_Time( FixTime_Value: String): String;
    function Colon_count( _Value: String): Integer;
    begin
         Result:= 0;
@@ -123,19 +123,21 @@ procedure TTreeData.SetValue( _Value: String);
           Inc(Result);
           end;
    end;
+begin
+  case Colon_count( FixTime_Value)
+  of
+    0: Fix_Time:= '0:0:'+FixTime_Value;
+    1: Fix_Time:= '0:'  +FixTime_Value;
+    2: Fix_Time:=        FixTime_Value;
+    end;
+end;
+
+procedure TTreeData.SetValue( _Value: String);
    procedure FdValue_from_FValue;
-   var
-      s: String;
-   begin
-        case Colon_count( FValue)
-        of
-          0: s:= '0:0:'+FValue;
-          1: s:= '0:'  +FValue;
-          2: s:=        FValue;
-          end;
-        if not TryStrToDateTime( s, FdValue)
-        then
-            FdValue:= 0;
+   Begin
+      if not TryStrToDateTime( Fix_Time(FValue), FdValue)
+      then
+         FdValue:= 0;
    end;
 begin
      FValue:= _Value;
@@ -446,11 +448,13 @@ begin
 end;
 
 function ThVirtualStringTree.Get_Checked_or_Selected: String;
+var
+   Load_Time,Total_Run_Time,Total_Machine_Time : TDateTime;
+
    procedure CheckChilds( _Parent: PVirtualNode; _Parent_Checked, _Parent_Selected: Boolean);
    var
       vn: PVirtualNode;
       Checked, Selected: Boolean;
-      td: TTreeData;
       procedure Process_TreeData;
       var
          td: TTreeData;
@@ -458,6 +462,8 @@ function ThVirtualStringTree.Get_Checked_or_Selected: String;
            td:= TreeData_from_Node( vn);
            if not td.IsLeaf then exit;
            Formate_Liste( Result, #13#10, td.Key+'='+td.Value);
+           Total_Machine_Time:=Total_Machine_Time+td.dValue;
+           Total_Run_Time:=Total_Run_Time+td.dValue+Load_Time;
       end;
    begin
         vn:= vst.GetFirstChild(_Parent);
@@ -467,14 +473,23 @@ function ThVirtualStringTree.Get_Checked_or_Selected: String;
           Checked:= _Parent_Checked or (csCheckedNormal = vn^.CheckState);
           Selected:= _Parent_Selected or vst.Selected[vn];
           if Checked or Selected then Process_TreeData;
-
           CheckChilds( vn, Checked, Selected);
           vn:= vst.GetNextSibling(vn);
           end;
    end;
 begin
+     //I don't know why I can't pull the value from the eLoadTime box
+     //if not TryStrToDateTime( Fix_Time(TfFileVirtualTree.eLoadTime.Text), Load_Time) then Load_Time:= 0;
+     if not TryStrToDateTime( Fix_Time('4:32'), Load_Time) then Load_Time:= 0;
+     Total_Run_Time:=0;
+     Total_Machine_Time:=0;
      Result:= '';
      CheckChilds( vst.RootNode, False, False);
+     //I don't know why I can't fill in these text boxes?? 
+     //TfFileVirtualTreee.RunTime.Text:=Duration_From_DateTime(Total_Run_Time);
+     //TfFileVirtualTree.eMachineTime.Text:=Duration_From_DateTime(Total_Machine_Time);
+     Formate_Liste( Result, #13#10#13#10, 'Total Run Time: '+Duration_From_DateTime(Total_Machine_Time));
+     Result:='Total Time Including Loading: '+Duration_From_DateTime(Total_Run_Time)+#13#10#13#10+Result;
 end;
 
 procedure ThVirtualStringTree.vstChecked( Sender: TBaseVirtualTree;

--- a/tools/FileTree/ufFileVirtualTree.lfm
+++ b/tools/FileTree/ufFileVirtualTree.lfm
@@ -1,11 +1,11 @@
 object fFileVirtualTree: TfFileVirtualTree
-  Left = 418
-  Height = 240
-  Top = 297
-  Width = 793
+  Left = 1024
+  Height = 779
+  Top = 304
+  Width = 1100
   Caption = 'fFileVirtualTree'
-  ClientHeight = 240
-  ClientWidth = 793
+  ClientHeight = 779
+  ClientWidth = 1100
   OnCreate = FormCreate
   OnDestroy = FormDestroy
   Position = poDesktopCenter
@@ -15,10 +15,10 @@ object fFileVirtualTree: TfFileVirtualTree
     Left = 0
     Height = 98
     Top = 0
-    Width = 793
+    Width = 1100
     Align = alTop
     ClientHeight = 98
-    ClientWidth = 793
+    ClientWidth = 1100
     TabOrder = 0
     object bGetSelection: TButton
       Left = 159
@@ -85,7 +85,7 @@ object fFileVirtualTree: TfFileVirtualTree
       Left = 1
       Height = 20
       Top = 77
-      Width = 791
+      Width = 1098
       Align = alBottom
       TabOrder = 6
     end
@@ -116,19 +116,65 @@ object fFileVirtualTree: TfFileVirtualTree
       OnClick = bTest_Duration_from_DateTimeClick
       TabOrder = 8
     end
+    object eLoadTime: TEdit
+      Left = 799
+      Height = 23
+      Top = 24
+      Width = 80
+      TabOrder = 9
+      Text = '4:32'
+    end
+    object Label2: TLabel
+      Left = 800
+      Height = 15
+      Top = 8
+      Width = 55
+      Caption = 'Load Time'
+      ParentColor = False
+    end
+    object Label3: TLabel
+      Left = 896
+      Height = 15
+      Top = 8
+      Width = 50
+      Caption = 'Run Time'
+      ParentColor = False
+    end
+    object Label4: TLabel
+      Left = 992
+      Height = 15
+      Top = 8
+      Width = 75
+      Caption = 'Machine Time'
+      ParentColor = False
+    end
+    object eRunTime: TEdit
+      Left = 896
+      Height = 23
+      Top = 24
+      Width = 80
+      TabOrder = 10
+    end
+    object eMachineTime: TEdit
+      Left = 992
+      Height = 23
+      Top = 24
+      Width = 80
+      TabOrder = 11
+    end
   end
   object Panel2: TPanel
     Left = 0
-    Height = 142
+    Height = 681
     Top = 98
-    Width = 793
+    Width = 1100
     Align = alClient
-    ClientHeight = 142
-    ClientWidth = 793
+    ClientHeight = 681
+    ClientWidth = 1100
     TabOrder = 1
     object Splitter1: TSplitter
-      Left = 285
-      Height = 140
+      Left = 592
+      Height = 679
       Top = 1
       Width = 5
       Align = alRight
@@ -138,9 +184,9 @@ object fFileVirtualTree: TfFileVirtualTree
     end
     object vst: TVirtualStringTree
       Left = 1
-      Height = 140
+      Height = 679
       Top = 1
-      Width = 284
+      Width = 591
       Align = alClient
       DefaultNodeHeight = 21
       DefaultText = 'Node'
@@ -161,13 +207,13 @@ object fFileVirtualTree: TfFileVirtualTree
       TreeOptions.SelectionOptions = [toMultiSelect]
     end
     object Panel3: TPanel
-      Left = 290
-      Height = 140
+      Left = 597
+      Height = 679
       Top = 1
       Width = 502
       Align = alRight
       Caption = 'Panel3'
-      ClientHeight = 140
+      ClientHeight = 679
       ClientWidth = 502
       TabOrder = 2
       object m: TMemo
@@ -197,7 +243,7 @@ object fFileVirtualTree: TfFileVirtualTree
       end
       object vstResult: TVirtualStringTree
         Left = 1
-        Height = 67
+        Height = 606
         Top = 72
         Width = 500
         Align = alClient

--- a/tools/FileTree/ufFileVirtualTree.pas
+++ b/tools/FileTree/ufFileVirtualTree.pas
@@ -27,8 +27,14 @@ type
    bOD: TButton;
    bTest_Duration_from_DateTime: TButton;
    eFileName: TEdit;
+   eLoadTime: TEdit;
+   eRunTime: TEdit;
+   eMachineTime: TEdit;
    ips: TIniPropStorage;
    Label1: TLabel;
+   Label2: TLabel;
+   Label3: TLabel;
+   Label4: TLabel;
    lCompute_Aggregates: TLabel;
    m: TMemo;
    od: TOpenDialog;


### PR DESCRIPTION
add load time in to each program
report total machine time and total run time

I don't know why I can't use the text boxes. I tried Fix_Time(eLoadTime.Text) and Fix_Time(TfFileVirtualTree.eLoadTime.Text)
and it always says it can't find eLoadTime, but I see it right there.. so I just don't know what I'm doing wrong.  I commented out filling in the text boxes and the rest of it works and it adds a summary at the bottom of the file list report